### PR TITLE
카테고리 변경 시 포스트 업데이트 에러 수정

### DIFF
--- a/front/src/routes/Blog/BlogContainer.tsx
+++ b/front/src/routes/Blog/BlogContainer.tsx
@@ -14,7 +14,7 @@ const BlogContainer = () => {
   const [category, setCategory] = useState(null);
   const [tagId, setTagId] = useState(null);
   const [searchWord, , onChangeSearchWord] = useChangeEvent<HTMLInputElement>('');
-  const lastId = useRef(null);
+  const lastId = useRef({});
   const { data: postData, fetchMore, refetch } = useQuery<getPosts>(GET_POSTS, { variables: { category, tagId } });
   const { data: tagData } = useQuery<getTags>(GET_TAGS);
 
@@ -27,15 +27,16 @@ const BlogContainer = () => {
     const posts = postData?.GetPosts?.posts;
     if (
       posts &&
-      lastId.current !== posts?.[posts.length - 1].id &&
+      lastId.current[category] !== posts?.[posts.length - 1].id &&
       document.body.scrollTop + document.body.clientHeight > document.body.scrollHeight - 400
     ) {
-      lastId.current = posts[posts.length - 1].id;
+      console.log('req');
+      lastId.current[category] = posts[posts.length - 1].id;
       fetchMore({
         variables: {
           category,
           tagId,
-          lastId: lastId.current,
+          lastId: lastId.current[category],
         },
         updateQuery: (prev, { fetchMoreResult }) => {
           if (!fetchMoreResult) {

--- a/front/src/routes/Blog/BlogPresenter.tsx
+++ b/front/src/routes/Blog/BlogPresenter.tsx
@@ -30,6 +30,9 @@ const path = [
   { path: '/blog', name: 'BLOG' },
 ];
 
+const CATEGORY_DIARY = 'DIARY';
+const CATEGORY_DEV = 'DEV';
+
 const BlogPresenter = ({
   userInfo,
   category,
@@ -65,10 +68,10 @@ const BlogPresenter = ({
               <NavItem onClick={() => onChangeCategory(null)} currrentFocus={category === null}>
                 All
               </NavItem>
-              <NavItem onClick={() => onChangeCategory('DIARY')} currrentFocus={category === 'DIARY'}>
+              <NavItem onClick={() => onChangeCategory(CATEGORY_DIARY)} currrentFocus={category === CATEGORY_DIARY}>
                 diary
               </NavItem>
-              <NavItem onClick={() => onChangeCategory('DEV')} currrentFocus={category === 'DEV'}>
+              <NavItem onClick={() => onChangeCategory(CATEGORY_DEV)} currrentFocus={category === CATEGORY_DEV}>
                 dev
               </NavItem>
             </div>


### PR DESCRIPTION
- 카테고리 변경 시에도 포스트 업데이트에 사용하던 lastId값이 그대로 유지되어 포스트가 업데이트 되지 않던 버그 발견
- lastId를 객체로 만든 후 카테고리 별로 프로퍼티를 생성해 각각 다른 lastId값들을 갖도록 설정