### PR TITLE
Cyjo/About페이지에 경험(경력) 추가

### DIFF
--- a/back/README.md
+++ b/back/README.md
@@ -42,3 +42,4 @@ Back-End Server for the chanyeong webpage on chanyeong. GraphQL, Typescript, Nod
 - [x]  Delete Post
 - [x]  Fix Post
 - [x]  Add Experience
+- [x]  Delete Experience

--- a/back/README.md
+++ b/back/README.md
@@ -42,4 +42,5 @@ Back-End Server for the chanyeong webpage on chanyeong. GraphQL, Typescript, Nod
 - [x]  Delete Post
 - [x]  Fix Post
 - [x]  Add Experience
+- [x]  Edit Experience
 - [x]  Delete Experience

--- a/back/README.md
+++ b/back/README.md
@@ -26,6 +26,7 @@ Back-End Server for the chanyeong webpage on chanyeong. GraphQL, Typescript, Nod
 - [x]  Get Post
 - [x]  Get Picked Posts
 - [x]  Get Tag Posts
+- [x]  Get Experience
 
 ### Private Resolvers:
 

--- a/back/README.md
+++ b/back/README.md
@@ -26,7 +26,7 @@ Back-End Server for the chanyeong webpage on chanyeong. GraphQL, Typescript, Nod
 - [x]  Get Post
 - [x]  Get Picked Posts
 - [x]  Get Tag Posts
-- [x]  Get Experience
+- [x]  Get Experiences
 
 ### Private Resolvers:
 
@@ -41,3 +41,4 @@ Back-End Server for the chanyeong webpage on chanyeong. GraphQL, Typescript, Nod
 - [x]  Edit Post
 - [x]  Delete Post
 - [x]  Fix Post
+- [x]  Add Experience

--- a/back/src/api/Experience/AddExperience/AddExperience.graphql
+++ b/back/src/api/Experience/AddExperience/AddExperience.graphql
@@ -1,0 +1,13 @@
+type AddExperienceResponse {
+    ok: Boolean!
+    error: String
+}
+
+type Mutation {
+    AddExperience(
+        startDate: String!
+        endDate: String
+        title: String!
+        content: String!
+    ): AddExperienceResponse!
+}

--- a/back/src/api/Experience/AddExperience/AddExperience.resolvers.ts
+++ b/back/src/api/Experience/AddExperience/AddExperience.resolvers.ts
@@ -1,0 +1,31 @@
+import { AddExperienceMutationArgs } from '../../../types/graph';
+import { Resolvers } from '../../../types/resolvers';
+
+import Experience from '../../../models/Experience';
+import privateResolver from '../../../utils/privateResolver';
+
+/** AddExperience
+ *  경험 등록
+ */
+const resolvers: Resolvers = {
+  Mutation: {
+    AddExperience: privateResolver(async (_, args: AddExperienceMutationArgs) => {
+      try {
+        const { startDate, endDate, title, content } = args;
+
+        await Experience.create({ startDate, endDate, title, content });
+
+        return {
+          ok: true,
+        };
+      } catch (error) {
+        return {
+          ok: false,
+          error,
+        };
+      }
+    }),
+  },
+};
+
+export default resolvers;

--- a/back/src/api/Experience/DeleteExperience/DeleteExperience.graphql
+++ b/back/src/api/Experience/DeleteExperience/DeleteExperience.graphql
@@ -1,0 +1,8 @@
+type DeleteExperienceResponse {
+    ok: Boolean!
+    error: String
+}
+
+type Mutation {
+    DeleteExperience(id: Int!): DeleteExperienceResponse!
+}

--- a/back/src/api/Experience/DeleteExperience/DeleteExperience.resolvers.ts
+++ b/back/src/api/Experience/DeleteExperience/DeleteExperience.resolvers.ts
@@ -1,0 +1,31 @@
+import { DeleteExperienceMutationArgs } from '../../../types/graph';
+import { Resolvers } from '../../../types/resolvers';
+
+import Experience from '../../../models/Experience';
+import privateResolver from '../../../utils/privateResolver';
+
+/** DeleteExperience
+ *  경험 제거
+ */
+const resolvers: Resolvers = {
+  Mutation: {
+    DeleteExperience: privateResolver(async (_, args: DeleteExperienceMutationArgs) => {
+      try {
+        const { id } = args;
+
+        await Experience.destroy({ where: { id } });
+
+        return {
+          ok: true,
+        };
+      } catch (error) {
+        return {
+          ok: false,
+          error,
+        };
+      }
+    }),
+  },
+};
+
+export default resolvers;

--- a/back/src/api/Experience/EditExperience/EditExperience.graphql
+++ b/back/src/api/Experience/EditExperience/EditExperience.graphql
@@ -1,0 +1,14 @@
+type EditExperienceResponse {
+    ok: Boolean!
+    error: String
+}
+
+type Mutation {
+    EditExperience(
+        id: Int!
+        startDate: String
+        endDate: String
+        title: String
+        content: String
+    ): EditExperienceResponse!
+}

--- a/back/src/api/Experience/EditExperience/EditExperience.resolvers.ts
+++ b/back/src/api/Experience/EditExperience/EditExperience.resolvers.ts
@@ -1,0 +1,39 @@
+import { EditExperienceMutationArgs } from '../../../types/graph';
+import { Resolvers } from '../../../types/resolvers';
+
+import Experience from '../../../models/Experience';
+import privateResolver from '../../../utils/privateResolver';
+
+/** EditExperience
+ *  경험 수정
+ */
+const resolvers: Resolvers = {
+  Mutation: {
+    EditExperience: privateResolver(async (_, args: EditExperienceMutationArgs) => {
+      try {
+        const { id, startDate, endDate, title, content } = args;
+
+        await Experience.update(
+          {
+            startDate,
+            endDate,
+            title,
+            content,
+          },
+          { where: { id } },
+        );
+
+        return {
+          ok: true,
+        };
+      } catch (error) {
+        return {
+          ok: false,
+          error,
+        };
+      }
+    }),
+  },
+};
+
+export default resolvers;

--- a/back/src/api/Experience/GetExperience/GetExperience.graphql
+++ b/back/src/api/Experience/GetExperience/GetExperience.graphql
@@ -1,0 +1,9 @@
+type GetExperiencesResponse {
+    ok: Boolean!
+    error: String
+    experiences: [Experience]
+}
+
+type Query {
+    GetExperiences: GetExperiencesResponse!
+}

--- a/back/src/api/Experience/GetExperience/GetExperience.resolvers.ts
+++ b/back/src/api/Experience/GetExperience/GetExperience.resolvers.ts
@@ -1,0 +1,30 @@
+import { Resolvers } from '../../../types/resolvers';
+
+import Experience from '../../../models/Experience';
+
+/** GetPickedPosts
+ *  picked 포스트 조회
+ */
+const resolvers: Resolvers = {
+  Query: {
+    GetExperiences: async () => {
+      try {
+        const experiences = await Experience.findAll({
+          order: [['startDate', 'ASC']],
+        });
+
+        return {
+          ok: true,
+          experiences,
+        };
+      } catch (error) {
+        return {
+          ok: false,
+          error,
+        };
+      }
+    },
+  },
+};
+
+export default resolvers;

--- a/back/src/api/Experience/GetExperience/GetExperience.resolvers.ts
+++ b/back/src/api/Experience/GetExperience/GetExperience.resolvers.ts
@@ -2,8 +2,8 @@ import { Resolvers } from '../../../types/resolvers';
 
 import Experience from '../../../models/Experience';
 
-/** GetPickedPosts
- *  picked 포스트 조회
+/** GetExperiences
+ *  경험 목록 조회
  */
 const resolvers: Resolvers = {
   Query: {

--- a/back/src/api/Experience/shared/Experience.graphql
+++ b/back/src/api/Experience/shared/Experience.graphql
@@ -1,0 +1,7 @@
+type Experience {
+    id: Int!
+    startDate: String!
+    endDate: String
+    title: String!
+    content: String!
+}

--- a/back/src/api/Skill/GetGroupedSkills/GetGroupedSkills.graphql
+++ b/back/src/api/Skill/GetGroupedSkills/GetGroupedSkills.graphql
@@ -1,0 +1,15 @@
+type GroupedSkills {
+    front: [Skill]
+    back: [Skill]
+    devops: [Skill]
+}
+
+type GetGroupedSkillsResponse {
+    ok: Boolean!
+    error: String
+    skills: GroupedSkills
+}
+
+type Query {
+    GetGroupedSkills: GetGroupedSkillsResponse!
+}

--- a/back/src/api/Skill/GetGroupedSkills/GetGroupedSkills.resolvers.ts
+++ b/back/src/api/Skill/GetGroupedSkills/GetGroupedSkills.resolvers.ts
@@ -1,0 +1,46 @@
+import { GroupedSkills, Skill as SkillType } from '../../../types/graph';
+import { Resolvers } from '../../../types/resolvers';
+
+import Skill, { SKILL_TYPE } from '../../../models/Skill';
+
+/** GetGroupedSkills
+ *  FRONT_END, BACK_END, DEV_OPS 을 그룹별로 반환
+ */
+const resolvers: Resolvers = {
+  Query: {
+    GetGroupedSkills: async () => {
+      try {
+        const totalSkills = await Skill.findAll({ order: [['order', 'ASC']] });
+        const skills = totalSkills.reduce(
+          (groupedSkill: GroupedSkills, skill: SkillType) => {
+            if (skill.type === SKILL_TYPE.FRONT_END) {
+              groupedSkill.front!.push(skill);
+              return groupedSkill;
+            }
+
+            if (skill.type === SKILL_TYPE.BACK_END) {
+              groupedSkill.back!.push(skill);
+              return groupedSkill;
+            }
+
+            groupedSkill.devops!.push(skill);
+            return groupedSkill;
+          },
+          { front: [], back: [], devops: [] },
+        );
+
+        return {
+          ok: true,
+          skills,
+        };
+      } catch (error) {
+        return {
+          ok: false,
+          error,
+        };
+      }
+    },
+  },
+};
+
+export default resolvers;

--- a/back/src/models/Experience.ts
+++ b/back/src/models/Experience.ts
@@ -21,7 +21,7 @@ Experience.init(
     },
     endDate: {
       type: DataTypes.DATEONLY,
-      allowNull: false,
+      allowNull: true,
     },
     title: {
       type: DataTypes.STRING(50),

--- a/back/src/models/Experience.ts
+++ b/back/src/models/Experience.ts
@@ -1,0 +1,44 @@
+import { Model, DataTypes } from 'sequelize';
+import { sequelize } from './sequelize';
+
+class Experience extends Model {
+  public readonly id!: number;
+
+  public startDate!: Date;
+
+  public endDate?: Date;
+
+  public title!: string;
+
+  public content!: string;
+}
+
+Experience.init(
+  {
+    startDate: {
+      type: DataTypes.DATEONLY,
+      allowNull: false,
+    },
+    endDate: {
+      type: DataTypes.DATEONLY,
+      allowNull: false,
+    },
+    title: {
+      type: DataTypes.STRING(50),
+      allowNull: false,
+    },
+    content: {
+      type: DataTypes.TEXT,
+      allowNull: false,
+    },
+  },
+  {
+    sequelize,
+    modelName: 'Experience',
+    tableName: 'experience',
+    charset: 'utf8mb4',
+    collate: 'utf8mb4_general_ci',
+  },
+);
+
+export default Experience;

--- a/back/src/models/Skill.ts
+++ b/back/src/models/Skill.ts
@@ -3,6 +3,12 @@ import { sequelize } from './sequelize';
 import { dbType } from './index';
 import { SkillType } from '../types/graph';
 
+export const enum SKILL_TYPE {
+  FRONT_END = 'FRONT_END',
+  BACK_END = 'BACK_END',
+  DEV_OPS = 'DEV_OPS',
+}
+
 class Skill extends Model {
   public readonly id!: number;
 
@@ -27,7 +33,7 @@ Skill.init(
       unique: true,
     },
     type: {
-      type: DataTypes.ENUM('FRONT_END', 'BACK_END', 'DEV_OPS'),
+      type: DataTypes.ENUM(SKILL_TYPE.FRONT_END, SKILL_TYPE.BACK_END, SKILL_TYPE.DEV_OPS),
       allowNull: false,
     },
     level: {

--- a/back/src/models/index.ts
+++ b/back/src/models/index.ts
@@ -3,6 +3,7 @@ import Project, { associate as associateProject } from './Project';
 import Post, { associate as associatePost } from './Post';
 import Skill, { associate as associateSkill } from './Skill';
 import Tag, { associate as associateTag } from './Tag';
+import Experience from './Experience';
 
 export * from './sequelize';
 
@@ -12,6 +13,7 @@ const db = {
   Post,
   Skill,
   Tag,
+  Experience,
 };
 
 export type dbType = typeof db;

--- a/front/src/component/ExperienceCard/ExperienceCard.tsx
+++ b/front/src/component/ExperienceCard/ExperienceCard.tsx
@@ -1,0 +1,31 @@
+import React, { useMemo } from 'react';
+
+import { getAbouts_GetExperiences_experiences } from '@gql-types/api';
+import newLine from '@lib/newLine';
+import { ExperienceCardWrapper, ExperienceDate, ExperienceContent, Term } from './styled';
+
+interface Props {
+  experience: getAbouts_GetExperiences_experiences;
+}
+
+const ExperienceCard = ({ experience }: Props) => {
+  const term = useMemo(() => {
+    const dateGap = +new Date(experience.endDate || Date.now()) - +new Date(experience.startDate);
+    return Math.round(dateGap / (1000 * 60 * 60 * 24 * 30));
+  }, []);
+
+  return (
+    <ExperienceCardWrapper>
+      <ExperienceDate>
+        <span>{`${experience.startDate} ~ ${experience.endDate || '진행 중'}`}</span>
+        <Term>{`${term}개월`}</Term>
+      </ExperienceDate>
+      <ExperienceContent>
+        <h1>{experience.title}</h1>
+        <div>{newLine(experience.content)}</div>
+      </ExperienceContent>
+    </ExperienceCardWrapper>
+  );
+};
+
+export default ExperienceCard;

--- a/front/src/component/ExperienceCard/index.ts
+++ b/front/src/component/ExperienceCard/index.ts
@@ -1,0 +1,1 @@
+export { default } from './ExperienceCard';

--- a/front/src/component/ExperienceCard/styled.ts
+++ b/front/src/component/ExperienceCard/styled.ts
@@ -1,0 +1,31 @@
+import styled from 'styled-components';
+
+export const ExperienceCardWrapper = styled.div`
+  display: flex;
+  margin-top: 8px;
+  margin-left: 16px;
+`;
+
+export const ExperienceDate = styled.div`
+  display: flex;
+  flex-direction: column;
+  align-items: flex-end;
+  margin-top: 4px;
+  margin-right: 40px;
+  font-size: 16px;
+  font-weight: 700;
+  width: 200px;
+`;
+
+export const ExperienceContent = styled.div`
+  margin-bottom: 16px;
+  & > h1 {
+    font-size: 22px;
+    font-weight: 700;
+  }
+`;
+
+export const Term = styled.span`
+  font-size: 12px;
+  font-weight: 500;
+`;

--- a/front/src/lib/newLine.tsx
+++ b/front/src/lib/newLine.tsx
@@ -1,0 +1,13 @@
+import React from 'react';
+
+const newLine = (text: string) => {
+  const splitText = text.split('\n');
+  return splitText.map((line, index) => (
+    <>
+      {line}
+      {index !== splitText.length && <br />}
+    </>
+  ));
+};
+
+export default newLine;

--- a/front/src/queries/about.queries.ts
+++ b/front/src/queries/about.queries.ts
@@ -1,0 +1,50 @@
+import gql from 'graphql-tag';
+
+export const GET_ABOUTS = gql`
+  query getAbouts {
+    GetExperiences {
+      ok
+      error
+      experiences {
+        id
+        startDate
+        endDate
+        title
+        content
+      }
+    }
+    GetGroupedSkills {
+      ok
+      error
+      skills {
+        front {
+          id
+          name
+          type
+          level
+          description
+          icon
+          order
+        }
+        back {
+          id
+          name
+          type
+          level
+          description
+          icon
+          order
+        }
+        devops {
+          id
+          name
+          type
+          level
+          description
+          icon
+          order
+        }
+      }
+    }
+  }
+`;

--- a/front/src/routes/About/AboutContainer.tsx
+++ b/front/src/routes/About/AboutContainer.tsx
@@ -41,6 +41,7 @@ const AboutContainer = ({ GetExperiences, GetGroupedSkills }: Props) => {
       frontSkills={GetGroupedSkills?.skills.front || []}
       backSkills={GetGroupedSkills?.skills.back || []}
       devopsSkills={GetGroupedSkills?.skills.devops || []}
+      experiences={GetExperiences?.experiences || []}
       editSkillData={editSkillData}
       onClickAddSkill={onClickAddSkill}
       onClickEditSkill={onClickEditSkill}

--- a/front/src/routes/About/AboutContainer.tsx
+++ b/front/src/routes/About/AboutContainer.tsx
@@ -1,18 +1,20 @@
 import React, { useState, useCallback, useEffect } from 'react';
 import { useQuery } from '@apollo/react-hooks';
 
-import { getSkills, getSkills_GetSkills_skill } from '@gql-types/api';
-import { GET_SKILLS } from '@queries/skill.queries';
+import { getSkills_GetSkills_skill, getAbouts_GetExperiences, getAbouts_GetGroupedSkills } from '@gql-types/api';
+import { GET_ABOUTS } from '@queries/about.queries';
 import { GET_LOCAL_USER } from '@queries/client';
 import AboutPresenter from './AboutPresenter';
 
-const AboutContainer = () => {
+interface Props {
+  GetExperiences: getAbouts_GetExperiences;
+  GetGroupedSkills: getAbouts_GetGroupedSkills;
+}
+
+const AboutContainer = ({ GetExperiences, GetGroupedSkills }: Props) => {
   const { data: userInfo } = useQuery(GET_LOCAL_USER);
   const [openAddSkill, setOpenAddSkill] = useState(false);
   const [editSkillData, setEditSkillData] = useState<getSkills_GetSkills_skill | null>(null);
-  const { data: frontData } = useQuery<getSkills>(GET_SKILLS, { variables: { type: 'FRONT_END' } });
-  const { data: backData } = useQuery<getSkills>(GET_SKILLS, { variables: { type: 'BACK_END' } });
-  const { data: devopsData } = useQuery<getSkills>(GET_SKILLS, { variables: { type: 'DEV_OPS' } });
 
   useEffect(() => {
     document.body.scrollTo(0, 0);
@@ -36,15 +38,24 @@ const AboutContainer = () => {
     <AboutPresenter
       openAddSkill={openAddSkill}
       userInfo={userInfo}
-      frontSkills={frontData?.GetSkills.skill}
-      backSkills={backData?.GetSkills.skill}
-      devopsSkills={devopsData?.GetSkills.skill}
+      frontSkills={GetGroupedSkills?.skills.front || []}
+      backSkills={GetGroupedSkills?.skills.back || []}
+      devopsSkills={GetGroupedSkills?.skills.devops || []}
       editSkillData={editSkillData}
       onClickAddSkill={onClickAddSkill}
       onClickEditSkill={onClickEditSkill}
       closeUpdateSKill={closeUpdateSKill}
     />
   );
+};
+
+AboutContainer.getInitialProps = async (context) => {
+  const { apolloClient } = context;
+  apolloClient.cache.reset();
+  const { data } = await apolloClient.query({
+    query: GET_ABOUTS,
+  });
+  return data;
 };
 
 export default AboutContainer;

--- a/front/src/routes/About/AboutPresenter.tsx
+++ b/front/src/routes/About/AboutPresenter.tsx
@@ -5,13 +5,14 @@ import PageContainer from '@component/pageContainer';
 import PagePath from '@component/PagePath';
 import AboutValue from '@component/AboutValue';
 import AboutSkill from '@component/AboutSkill';
+import ExperienceCard from '@component/ExperienceCard';
 import Button from '@commons/Button';
 import Text, { TITLE } from '@commons/Text';
-import { getSkills_GetSkills_skill } from '@gql-types/api';
+import { getSkills_GetSkills_skill, getAbouts_GetExperiences_experiences } from '@gql-types/api';
 import UpdateSkillForm from '@component/UpdateSkillForm';
 import { LocalSignIn } from '@src/apollo';
 import WorkProcessItem from './WorkProcessItem';
-import { AboutWrapper, AboutItemWrapper, WorkProcessWrapper, SkillListWrapper } from './styled';
+import { AboutWrapper, AboutItemWrapper, WorkProcessWrapper, SkillListWrapper, ExperienceWrapper } from './styled';
 
 interface Props {
   openAddSkill: boolean;
@@ -19,6 +20,7 @@ interface Props {
   frontSkills: getSkills_GetSkills_skill[];
   backSkills: getSkills_GetSkills_skill[];
   devopsSkills: getSkills_GetSkills_skill[];
+  experiences: getAbouts_GetExperiences_experiences[];
   editSkillData: getSkills_GetSkills_skill;
   onClickAddSkill: () => void;
   onClickEditSkill: (data: getSkills_GetSkills_skill) => void;
@@ -39,6 +41,7 @@ const AboutPresenter = ({
   frontSkills,
   backSkills,
   devopsSkills,
+  experiences,
   editSkillData,
 }: Props) => (
   <>
@@ -120,6 +123,12 @@ const AboutPresenter = ({
             />
           ))}
         </SkillListWrapper>
+        <ExperienceWrapper>
+          <Text content="Experience" weight={700} size={TITLE} />
+          {experiences.map((experience) => (
+            <ExperienceCard key={`about_experience_${experience.id}`} experience={experience} />
+          ))}
+        </ExperienceWrapper>
       </AboutWrapper>
     </PageContainer>
   </>

--- a/front/src/routes/About/styled.ts
+++ b/front/src/routes/About/styled.ts
@@ -79,3 +79,7 @@ export const SkillListWrapper = styled.div`
     grid-template-columns: 1fr 1fr;
   }
 `;
+
+export const ExperienceWrapper = styled.div`
+  margin: 90px 0 30px;
+`;


### PR DESCRIPTION
### api server
- 경험 모델(테이블) 정의
- 경험 추가, 제거, 조회, 삭제 api 구현

### front server
- graphql query 구현
  - about 페이지에서 사용하는 데이터 한번에 가져오는 getAbouts 구현 (기존의 getSkills와 통합)
- 경험 컴포넌트 구현
- About 페이지 최 하단에 경험(경력) 구역 추가