### PR TITLE
Cyjo/About페이지 Experience 반응형 적용 및 블로그 레이아웃 약간 수정

### DIFF
--- a/front/src/component/ExperienceCard/styled.ts
+++ b/front/src/component/ExperienceCard/styled.ts
@@ -4,6 +4,11 @@ export const ExperienceCardWrapper = styled.div`
   display: flex;
   margin-top: 8px;
   margin-left: 16px;
+
+  @media (max-width: ${({ theme }) => theme.BP.MOBILE}) {
+    margin-left: 4px;
+    flex-direction: column;
+  }
 `;
 
 export const ExperienceDate = styled.div`
@@ -15,6 +20,16 @@ export const ExperienceDate = styled.div`
   font-size: 16px;
   font-weight: 700;
   width: 200px;
+
+  @media (max-width: ${({ theme }) => theme.BP.MOBILE}) {
+    flex-direction: row;
+    align-items: center;
+    width: 100%;
+
+    & > span {
+      margin-right: 8px;
+    }
+  }
 `;
 
 export const ExperienceContent = styled.div`

--- a/front/src/component/MarkdownViewer/renderers/code.tsx
+++ b/front/src/component/MarkdownViewer/renderers/code.tsx
@@ -13,6 +13,8 @@ import json from 'react-syntax-highlighter/dist/esm/languages/hljs/json';
 
 SyntaxHighlighter.registerLanguage('javascript', javascript);
 SyntaxHighlighter.registerLanguage('typescript', typescript);
+SyntaxHighlighter.registerLanguage('jsx', javascript);
+SyntaxHighlighter.registerLanguage('tsx', typescript);
 SyntaxHighlighter.registerLanguage('bash', bash);
 SyntaxHighlighter.registerLanguage('css', css);
 SyntaxHighlighter.registerLanguage('html', html);

--- a/front/src/component/MarkdownViewer/styled.ts
+++ b/front/src/component/MarkdownViewer/styled.ts
@@ -18,11 +18,28 @@ export const MarkdownWrapper = styled(ReactMarkdown)`
   }
 
   ul {
-    margin-left: 12px;
+    margin-left: 32px;
+    margin-bottom: 18px;
+
+    & > li::before {
+      position: absolute;
+      content: '';
+      width: 6px;
+      height: 6px;
+      border-radius: 50%;
+      transform: translateY(230%);
+      margin-left: -18px;
+      background-color: ${({ theme }) => theme.PRIMARY_FONT};
+    }
+
+    & p {
+      margin: 0;
+    }
   }
 
   ol {
     margin-left: 36px;
+    margin-bottom: 18px;
 
     & > li {
       counter-increment: li;
@@ -38,18 +55,6 @@ export const MarkdownWrapper = styled(ReactMarkdown)`
         margin: 8px 0;
       }
     }
-  }
-
-  ul > li::before {
-    display: inline-block;
-    position: relative;
-    content: '';
-    width: 6px;
-    height: 6px;
-    border-radius: 50%;
-    transform: translate(-50%, -50%);
-    margin-right: 8px;
-    background-color: ${({ theme }) => theme.PRIMARY_FONT};
   }
 
   & li {


### PR DESCRIPTION
- About페이지의 Experience에 모바일 반응형 적용
- 블로그의 code 렌더링 수정
  - jsx, tsx형식 추가
  - ul-li태그시 레이아웃이 무너지는 버그 수정