### PR TITLE
블로그 포스트 뷰 TOC 구현

### DIFF
--- a/front/src/components/UI/organisms/MarkDownViewer/MarkdownViewer.tsx
+++ b/front/src/components/UI/organisms/MarkDownViewer/MarkdownViewer.tsx
@@ -1,4 +1,6 @@
 import React from 'react';
+
+import { resetToc } from '@store/postToc';
 import { MarkdownWrapper } from './styled';
 import renderers from './renderers';
 
@@ -7,6 +9,8 @@ interface Props {
 }
 
 const MarkdownViewer = ({ content }: Props) => {
+  resetToc();
+
   return <MarkdownWrapper renderers={renderers}>{content}</MarkdownWrapper>;
 };
 

--- a/front/src/components/UI/organisms/MarkDownViewer/renderers/heading.tsx
+++ b/front/src/components/UI/organisms/MarkDownViewer/renderers/heading.tsx
@@ -1,17 +1,22 @@
 import React from 'react';
 
+import { addToc } from '@store/postToc';
+
 interface HeadingProps {
   level: number;
   children: React.ReactChildren[];
 }
 
 const flatten = (text, child) => {
-  return typeof child === 'string' ? text + child : React.Children.toArray(child.props.children).reduce(flatten, text);
+  return typeof child === 'string'
+    ? text + child
+    : React.Children.toArray(child.props.children).reduce(flatten, text);
 };
 
 const heading = ({ level, children }: HeadingProps) => {
   const text = children.reduce(flatten, '');
   const slug = text.toLowerCase().replace(/\s/g, '-');
+  addToc({ level, content: text, slug });
   return React.createElement(`h${level}`, { id: slug }, children);
 };
 

--- a/front/src/components/UI/organisms/Toc/Toc.tsx
+++ b/front/src/components/UI/organisms/Toc/Toc.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useCallback } from 'react';
 import { useReactiveVar } from '@apollo/client';
 
 import styled from '@theme/styled';
@@ -14,9 +14,10 @@ const StyledToc = styled.aside`
   top: 80px;
   height: fit-content;
   border-left: 4px solid ${({ theme }) => theme.LIGHT_GREY};
-  padding-left: 10px;
+  padding-left: 18px;
 
-  & > a {
+  & > span {
+    cursor: pointer;
     font-size: 12px;
     margin: 6px 0;
     color: ${({ theme }) => theme.LIGHT_GREY};
@@ -36,14 +37,28 @@ const StyledToc = styled.aside`
   }
 `;
 
+const HEADER_HEIGHT = 50;
+
 const Toc = () => {
   const tocs = useReactiveVar(tocVar);
+
+  const onClickToc = useCallback(
+    (slug: string) => () => {
+      document.body.scroll({
+        left: 0,
+        top: document.getElementById(slug).offsetTop - HEADER_HEIGHT,
+        behavior: 'smooth',
+      });
+    },
+    [],
+  );
+
   return (
     <StyledToc>
       {tocs.map((toc, i) => (
-        <a key={`${toc.slug}_${i}`} href={`#${toc.slug}`}>
+        <span key={`${toc.slug}_${i}`} onClick={onClickToc(toc.slug)}>
           {toc.content}
-        </a>
+        </span>
       ))}
     </StyledToc>
   );

--- a/front/src/components/UI/organisms/Toc/Toc.tsx
+++ b/front/src/components/UI/organisms/Toc/Toc.tsx
@@ -1,0 +1,52 @@
+import React from 'react';
+import { useReactiveVar } from '@apollo/client';
+
+import styled from '@theme/styled';
+import { tocVar } from '@store/postToc';
+
+const StyledToc = styled.aside`
+  margin-top: 18px;
+  box-sizing: border-box;
+  position: sticky;
+  display: flex;
+  flex-direction: column;
+  width: 20%;
+  top: 80px;
+  height: fit-content;
+  border-left: 4px solid ${({ theme }) => theme.LIGHT_GREY};
+  padding-left: 10px;
+
+  & > a {
+    font-size: 12px;
+    margin: 6px 0;
+    color: ${({ theme }) => theme.LIGHT_GREY};
+    font-weight: 700;
+    transition: color 0.5s;
+    overflow: hidden;
+    white-space: nowrap;
+    text-overflow: ellipsis;
+
+    &:hover {
+      color: ${({ theme }) => theme.A_LINK};
+    }
+  }
+
+  @media (max-width: ${({ theme }) => theme.BP.PC}) {
+    display: none;
+  }
+`;
+
+const Toc = () => {
+  const tocs = useReactiveVar(tocVar);
+  return (
+    <StyledToc>
+      {tocs.map((toc, i) => (
+        <a key={`${toc.slug}_${i}`} href={`#${toc.slug}`}>
+          {toc.content}
+        </a>
+      ))}
+    </StyledToc>
+  );
+};
+
+export default Toc;

--- a/front/src/components/UI/organisms/Toc/index.ts
+++ b/front/src/components/UI/organisms/Toc/index.ts
@@ -1,0 +1,1 @@
+export { default } from './Toc';

--- a/front/src/components/pages/BlogPost/BlogPostPresenter.tsx
+++ b/front/src/components/pages/BlogPost/BlogPostPresenter.tsx
@@ -5,6 +5,7 @@ import { DiscussionEmbed } from 'disqus-react';
 
 import RowFrame from '@frames/RowFrame';
 import MarkdownViewer from '@organisms/MarkDownViewer';
+import Toc from '@organisms/Toc';
 import BreadCrumbs from '@molecules/BreadCrumbs';
 import TagList from '@molecules/TagList';
 import Button from '@atoms/Button';
@@ -32,6 +33,20 @@ const StyledBlogPost = styled.div`
 
   & > section {
     margin-bottom: 56px;
+  }
+
+  & .post-content {
+    width: 100%;
+    display: flex;
+    justify-content: space-between;
+
+    & > div {
+      width: 78%;
+
+      @media (max-width: ${({ theme }) => theme.BP.PC}) {
+        width: 100%;
+      }
+    }
   }
 
   & #disqus_thread a {
@@ -95,7 +110,10 @@ const BlogPostPresenter = ({
             <TagList postId={post.id} tags={post.tags} />
           </header>
           <hr />
-          <MarkdownViewer content={post.content} />
+          <section className="post-content">
+            <MarkdownViewer content={post.content} />
+            <Toc />
+          </section>
         </section>
         <DiscussionEmbed
           shortname="canyeongyi-beulrogeu"

--- a/front/src/store/postToc.ts
+++ b/front/src/store/postToc.ts
@@ -1,0 +1,18 @@
+import { makeVar } from '@apollo/client';
+
+interface Toc {
+  level: number;
+  content: string;
+  slug: string;
+}
+
+export const tocVar = makeVar<Toc[]>([]);
+
+export const addToc = (heading: Toc) => {
+  const currentToc = tocVar();
+  tocVar([...currentToc, heading]);
+};
+
+export const resetToc = () => {
+  tocVar([]);
+};


### PR DESCRIPTION
### 블로그 포스트 뷰 TOC 구현
- 블로그 포스트 markdown 렌더링 시 toc 목록 저장
- toc 목록 클릭 시 부드러운 스크롤로 해당 heading 태그로 이동하도록 구현